### PR TITLE
Add autotune functionality and correct minor formatting issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.cargo

--- a/crates/cli_application/src/arg_handling.rs
+++ b/crates/cli_application/src/arg_handling.rs
@@ -63,22 +63,29 @@ pub struct Args {
 
     ///Determines the window size for the hashing algorithm.
     ///(e.g., "256K", "4KB", "64KiB")
-    #[arg(short, long, help_heading = "Tuning Parameters", default_value_t = ByteSize::b(2*1024))]
-    pub window: ByteSize,
+    ///Recommended value is 2kb.
+    #[arg(short, long, help_heading = "Tuning Parameters")]
+    pub window: Option<ByteSize>,
 
     ///Determines the dictionary size for the compression algorithm.
     ///(e.g., "256K", "4KB", "64KiB")
-    #[arg(short, long, help_heading = "Tuning Parameters", default_value_t = ByteSize::b(16*1024))]
-    pub dictionary: ByteSize,
+    ///Recommended value is 16kb.
+    #[arg(short, long, help_heading = "Tuning Parameters")]
+    pub dictionary: Option<ByteSize>,
 
     ///Autotune both the window size and dictionary size. Will find the 
     /// reasonably optimal size for each. This uses a somewhat inefficient 
     /// algorithm and can take time but will lead to a smaller file size
     /// more easily. If vlaues for either the window or dictionary are 
     /// provided they will be used instead of autotuning.
-    #[arg(short, long, help_heading = "Tuning Parameters", 
+    #[arg(long, help_heading = "Tuning Parameters", 
     default_value_t = false)]
     pub auto_tune: bool,
+
+    ///Sets the maximum time in seconds for each autotune iteration.
+    ///If an iteration exceeds this time, the latest result is used.
+    #[arg(long, help_heading = "Tuning Parameters")]
+    pub autotune_timeout: Option<u64>,
 
     ///When finalizing the archive, optimize the dictionary for better compression.
     /// NOT recommended for large files as it can be very slow. 

--- a/crates/cli_application/src/modes/compress.rs
+++ b/crates/cli_application/src/modes/compress.rs
@@ -8,12 +8,13 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use lib_sprite_shrink::{
-    FileManifestParent, ProcessedFileData, 
+    FileManifestParent, 
     create_file_manifest_and_chunks, finalize_archive, process_file_in_memory, 
-    rebuild_and_verify_single_file, serialize_uncompressed_data
+    rebuild_and_verify_single_file, serialize_uncompressed_data, test_compression
 };
 use rayon::prelude::*;
 
@@ -26,17 +27,23 @@ use crate::storage_io::{
 /// Executes the file compression and archiving process.
 ///
 /// This is the main entry point for the compression operation. It manages a
-/// multi-stage pipeline that reads input files, processes them in parallel
-/// to identify duplicate data chunks, and then serializes, verifies, and
-/// compresses the unique data into a final archive. The level of
-/// parallelism is configured based on the user's arguments.
+/// multi-stage pipeline that reads input files, processes them in parallel,
+/// and compresses them into a final archive file.
+///
+/// The function can automatically tune chunking and compression parameters
+/// for optimal size if `--auto-tune` is enabled. It also uses distinct
+/// thread configurations for I/O-bound and CPU-bound stages to enhance
+/// performance.
 ///
 /// # Arguments
 ///
 /// * `file_paths`: A vector of `PathBuf`s for all files to be included
 ///   in the archive.
 /// * `args`: A reference to the `Args` struct, containing all user-provided
-///   settings for compression, such as level, thread count, and memory use.
+///   settings. The `--auto-tune` flag enables parameter optimization. This
+///   can be partially overridden by providing an explicit `--window` or
+///   `--dictionary` value, which will skip the tuning for that specific
+///   parameter.
 ///
 /// # Returns
 ///
@@ -65,108 +72,203 @@ pub fn run_compression(
 
     /*Stores the chunk metadata for each file. 
     The key is the file name and the value is a FileManifestParent struct.*/
-    let file_manifest: DashMap<String, FileManifestParent> = DashMap::new();
+    let mut _file_manifest: DashMap<String, FileManifestParent> = DashMap::new();
     
     /*Stores each chunk and it's hash. 
     The key is the hash and the value is the byte data of the chunk.*/
-    let mut data_store: HashMap<u64, Vec<u8>> = HashMap::new();
+    let mut _data_store: HashMap<u64, Vec<u8>> = HashMap::new();
 
     /*Stores the SHA-512 hash for each file. 
     The String is the file name and the array is the 512 bit hash as a 64 byte 
     array.*/
-    let veri_hashes: DashMap<String, [u8; 64]> = DashMap::new();
+    let mut _veri_hashes: DashMap<String, [u8; 64]> = DashMap::new();
 
     /*Numerical compression level pulled from the args.*/
     let level: i32 = args.compression_level as i32;
 
     /*Stores the size of threads used by the parallel task of running 
     process_file_in_memory function.*/
-    let mut _read_threads: usize = 0;
+    let mut _process_threads: usize = 0;
 
     /*If low memory is set limit reads to one worker else set to the user 
     specified argument or let Rayon decide (which is the amount of threads the
     host system supports) */
     if args.low_memory {
-        _read_threads = 1 as usize;
+        _process_threads = 1 as usize;
         println!("Low memory mode engaged.")
     } else {
         /*0 lets Rayon decide the optimal number when thread parameter isn't 
         used, otherwise set to thread parameter.*/
-        _read_threads = args.threads.unwrap_or(0) as usize;
+        _process_threads = args.threads.unwrap_or(0) as usize;
     };
 
     /*Create read_pool to specify the amount of threads to be used by the 
     parallel process that follows it.*/
-    let read_pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(_read_threads)
+    let _process_pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(_process_threads)
         .build()
         .map_err(|e| CliError::InternalError(format!
             ("Failed to create thread pool: {}", e)))?;
 
-    let window_size = args.window.as_u64();
+    let mut best_window_size = args.window.map_or(
+        2 * 1024, |b| b.as_u64());
 
-    /*In parallel read and process each file. The resulting data is then stored
-    in a ProcessedFileData struct and added to the processed_files vector.*/
-    let processed_files: Vec<ProcessedFileData> = read_pool.install(|| {
-        file_paths
-            .par_iter()
-            .map(|path| {
-                //The application is responsible for I/O
-                let file_data = load_file(path)?;
-                //The library processes the in-memory data
-                process_file_in_memory(
-                    file_data, 
-                    window_size).map_err(CliError::from)
-            })
-            .filter_map(|result| result.transpose())
-            .collect::<Result<Vec<_>, _>>()
-    })?;
+    let mut best_dictionary_size = args.dictionary.map_or(
+        16 * 1024, |b| b.as_u64());
 
-    /*Sequentially process each ProcessedFileData struct and create a tuple 
-    contain a FileManifestParent struct (fmp) and a vector containing 
-    ProcessedFileData (chunk_data_list).
-    The loop then does the following for each fmp and chunk_data list:
-    - Adds the generated 512bit hash to the veri_hashes dash_map.
-    - Adds the fmp to the file_manifest.
-    - Adds the byte data as a vector to the data_store with the hash as the 
-    key.*/
-    for processed in processed_files {
-        let (fmp, chunk_data_list) = create_file_manifest_and_chunks(
-            &processed.file_name,
-            &processed.file_data,
-            &processed.chunks,
-        );
+    if args.auto_tune {
+        let timeout_dur = args.autotune_timeout.
+            map(Duration::from_secs);
+        //Starting window size
+        let mut current_window_size = 512;
 
-        veri_hashes.insert(processed.file_name.clone(), processed.veri_hash);
-        file_manifest.insert(processed.file_name, fmp);
-        for (hash, data) in chunk_data_list {
-            data_store.entry(hash).or_insert(data);
+        let mut last_compressed_size = usize::MAX;
+        
+        if args.window.is_none() {
+
+            loop {
+                println!("Testing window size: {}", current_window_size);
+
+                /*Set starting time for determining the compressed size 
+                using the current window size*/
+                let start_time = Instant::now();
+
+                //Process files with the current window size
+                let (_fm, 
+                    temp_data_store, 
+                    _vh) =
+                        process_files_with_window_size(
+                            &file_paths, 
+                            current_window_size, 
+                            &_process_pool)?;
+
+                //Serialize temporary data
+                let (_ser_file_manifest,
+                _ser_data_store, 
+                _chunk_index, 
+                sorted_hashes) = 
+                serialize_uncompressed_data(&_fm, &temp_data_store);
+
+                //Compress the data and measure the size
+                let compressed_size = test_compression(
+                    &temp_data_store, 
+                    &sorted_hashes, 
+                    _process_threads,
+                8192)?;
+                
+                /*Measure the time taken for determining the compressed size 
+                for the current window size*/
+                let elapsed = start_time.elapsed();
+
+                if compressed_size > last_compressed_size {
+                    //Process passed the optimal point, stop.
+                    println!("Optimal window size found to be {} bytes.", 
+                        best_window_size);
+                    break;
+                }
+
+                if let Some(timeout) = timeout_dur {
+                    if elapsed > timeout {
+                        println!(
+                            "Autotune for window size {} took too long (>{:?}). \
+                            Using best result so far: {}.",
+                            current_window_size, timeout, best_window_size
+                        );
+                        break; // Exit the loop
+                    }
+                }
+                
+                //This iteration was successful and an improvement
+                last_compressed_size = compressed_size;
+                best_window_size = current_window_size;
+
+                //Double value for next loop
+                current_window_size *= 2;
+            }
         }
+
+        (_file_manifest, _data_store, _veri_hashes) =
+            process_files_with_window_size(&file_paths, 
+                best_window_size, 
+                &_process_pool)?;
+        
+        let (_ser_fm, 
+            _sds, 
+            _ci, 
+            sorted_hashes) =
+            serialize_uncompressed_data(&_file_manifest, 
+                &_data_store);
+
+
+        last_compressed_size = usize::MAX;
+
+        //Starting dictionary size, 8kb
+        let mut current_dict_size: usize = 8192; 
+
+        loop {
+            if args.dictionary.is_none() {
+                println!("Testing dictionary size: {}", current_dict_size);
+                
+                let compressed_size = test_compression(
+                    &_data_store, 
+                    &sorted_hashes,
+                    _process_threads,
+                    current_dict_size)?;
+                
+                if compressed_size > last_compressed_size {
+                    //Process passed the optimal point, stop.
+                    println!("Optimal dictionary size found to be {} bytes.", 
+                        best_dictionary_size);
+                    break;
+                }
+                //This iteration was successful and an improvement
+                last_compressed_size = compressed_size;
+                best_dictionary_size = current_dict_size as u64;
+
+                //Double value for next loop
+                current_dict_size *= 2;
+
+                //Accept reasonable upper limit for dictionary size.
+                //This will stop it at an accepted value of 1024 * 512
+                if current_dict_size > 1024 * 1024 { 
+                    break;
+                }
+            }
+        } 
+    } else {
+
+        (_file_manifest, _data_store, _veri_hashes) =
+            process_files_with_window_size(&file_paths, 
+                best_window_size, 
+                &_process_pool)?;
     }
 
-    println!("{} chunks in data store.", data_store.len());
+    println!("{} unique chunks in data store.", _data_store.len());
 
     println!("All files processed. Verifying data...");
 
     /*If low memory is set limit reads to four workers else set to the user 
     specified argument or let Rayon decide (which is the amount of threads the
     host system supports) */
-    let mut _task_threads: usize = 0;
-    if args.low_memory {
-        _task_threads = 4;
-        println!("Low memory mode engaged.")
+    /*if args.low_memory {
+        compute_threads = 4;
     } else {
         /*0 lets Rayon decide the optimal number when thread parameter isn't 
         used, otherwise set to thread parameter.*/
-        _task_threads = args.threads.unwrap_or(0) as usize;
-    };
+        compute_threads = args.threads.unwrap_or(0) as usize;
+    };*/
+
+    let _compute_threads = 
+        if args.low_memory { 4 } 
+        else { args.threads.unwrap_or(0) };
 
     /*Create task_pool to specify the amount of threads to be used by the 
     rebuild_and_verify_single_file parallel process. */
-    let task_pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(_task_threads)
+    let _compute_pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(_compute_threads)
         .build()
-        .map_err(|e| CliError::InternalError(format!("Failed to create thread pool: {}", e)))?;
+        .map_err(|e| CliError::InternalError(
+            format!("Failed to create thread pool: {}", e)))?;
 
     /*Serialize and organize data. */
 
@@ -185,36 +287,40 @@ pub fn run_compression(
     
     /*Prepares and serializes all data for the final archive. See above for 
     each variable in the output tuple.*/
-    let (ser_file_manifest, ser_data_store, chunk_index, sorted_hashes) = 
-        serialize_uncompressed_data(&file_manifest, &data_store);
+    let (ser_file_manifest, 
+        ser_data_store, 
+        chunk_index, 
+        sorted_hashes) = 
+        serialize_uncompressed_data(&_file_manifest, &_data_store);
     
     /*Rebuilds each file and checks the SHA-512 hash for each.*/
-    task_pool.install(||{
+    _compute_pool.install(||{
         ser_file_manifest
             .par_iter()
             .try_for_each(|fmp| {
                 rebuild_and_verify_single_file(
-                    &fmp, &ser_data_store, &chunk_index, &veri_hashes)
+                    &fmp, &ser_data_store, &chunk_index, &_veri_hashes)
             })
     })?;
-    println!("File verification passed! Compressing data and finalizing archive...");
+    println!("File verification passed! Compressing data and \
+        finalizing archive...");
 
     /*chunk index was storing non compressed data_store locations and is no 
     longer needed.*/
     drop(chunk_index);
 
-    let dictionary_size = args.dictionary.as_u64();
+    //let dictionary_size = args.dictionary.as_u64();
     
     /*Assembles the final archive from its constituent parts, structures it 
     according to the ssmc spec and returns the byte data ready to be written.*/
     let ssmc_data = finalize_archive(
         &ser_file_manifest, 
-        &data_store, 
+        &_data_store, 
         &sorted_hashes, 
         file_paths.len() as u32, 
         level, 
-        dictionary_size,
-        _task_threads,
+        best_dictionary_size,
+        _compute_threads,
         args.optimize_dictionary)?;
 
     println!("Total file size will be: {} bytes.", ssmc_data.len());
@@ -222,10 +328,89 @@ pub fn run_compression(
     /*Takes the specified output file destination and adds the ssmc file 
     extension if it's not present or replaces the specified extension with
     ssmc.*/
-    let final_output_path = args.output.as_ref().unwrap().with_extension("ssmc");
+    let final_output_path = args.output
+        .as_ref()
+        .unwrap()
+        .with_extension("ssmc");
 
     //Write ssmc archive to disk.
     write_final_archive(&final_output_path, &ssmc_data)?;
 
     Ok(())
+}
+
+/// Processes a collection of files in parallel to produce core data structures.
+///
+/// This function reads multiple files from disk, chunks them using a
+/// specified window size, and generates the necessary metadata for archiving.
+/// It leverages a provided thread pool to perform I/O and processing
+/// concurrently, which is efficient for handling many files.
+///
+/// The results are organized into three thread-safe collections: a manifest
+/// of all files, a deduplicated data store of unique chunks, and a map of
+/// verification hashes for each file.
+///
+/// # Arguments
+///
+/// * `file_paths`: A slice of `PathBuf`s pointing to the input files.
+/// * `window_size`: A `u64` that defines the window size for the
+///   content-defined chunking algorithm.
+/// * `pool`: A reference to a configured `rayon::ThreadPool` that will be
+///   used to execute the file processing in parallel.
+///
+/// # Returns
+///
+/// A `Result` containing a tuple of three data structures:
+/// - A `DashMap` for the file manifest, mapping filenames to their metadata.
+/// - A `HashMap` for the data store, mapping chunk hashes to raw byte data.
+/// - A `DashMap` for verification hashes, mapping filenames to SHA-512 hashes.
+///
+/// On failure, it returns a `CliError`.
+fn process_files_with_window_size(
+    file_paths: &[PathBuf],
+    window_size: u64,
+    pool: &rayon::ThreadPool,
+) -> Result<(DashMap<String, FileManifestParent>, //file_manifest
+    HashMap<u64, Vec<u8>>, //data_store
+    DashMap<String, [u8; 64]>), //veri_hashes
+    CliError>
+{
+    //Read and process each file. Low memory mode limits this to 1 worker.
+    let processed_files = pool.install(|| {
+        file_paths
+            .par_iter()
+            .map(|path| {
+                //The application is responsible for I/O
+                let file_data = load_file(path)?;
+                //The library processes the in-memory data
+                process_file_in_memory(
+                    file_data, 
+                    window_size).map_err(CliError::from)
+            })
+            .filter_map(|result| result.transpose())
+            .collect::<Result<Vec<_>, _>>()
+    })?;
+
+    let file_manifest: DashMap<String, FileManifestParent> = DashMap::new();
+    let mut data_store: HashMap<u64, Vec<u8>> = HashMap::new();
+    let veri_hashes: DashMap<String, [u8; 64]> = DashMap::new();
+
+    //Data must be ordered sequentially.
+    for processed in processed_files {
+        let (fmp, 
+            chunk_data_list) = 
+            create_file_manifest_and_chunks(
+            &processed.file_name,
+            &processed.file_data,
+            &processed.chunks,
+        );
+        
+        veri_hashes.insert(processed.file_name.clone(), processed.veri_hash);
+        file_manifest.insert(processed.file_name, fmp);
+        for (hash, data) in chunk_data_list {
+            data_store.entry(hash).or_insert(data);
+        }
+    }
+
+    Ok((file_manifest, data_store, veri_hashes))
 }

--- a/crates/lib_sprite_shrink/src/archive.rs
+++ b/crates/lib_sprite_shrink/src/archive.rs
@@ -87,7 +87,7 @@ fn build_file_header(file_count: u32,
 /// A `Result` which is:
 /// - `Ok(Vec<u8>)` containing the compressed data as a byte vector.
 /// - `Err` if the compression process fails.
-fn compress_with_dict(data_payload: &[u8], dict: &[u8], level: &i32) -> 
+pub fn compress_with_dict(data_payload: &[u8], dict: &[u8], level: &i32) -> 
     Result<Vec<u8>, LibError>
 {
     //Create and initiate vector for storing compressed data bytes.

--- a/crates/lib_sprite_shrink/src/lib.rs
+++ b/crates/lib_sprite_shrink/src/lib.rs
@@ -8,7 +8,7 @@ pub use lib_error_handling::LibError;
 mod processing;
 pub use processing::{
     create_file_manifest_and_chunks, process_file_in_memory, 
-    rebuild_and_verify_single_file};
+    rebuild_and_verify_single_file, test_compression};
 
 mod parsing;
 pub use parsing::{
@@ -20,4 +20,6 @@ mod serialization;
 pub use serialization::{serialize_uncompressed_data};
 
 mod lib_structs;
-pub use lib_structs::{FileData, FileHeader, FileManifestParent, ProcessedFileData, SSAChunkMeta, ChunkLocation};
+pub use lib_structs::{
+    FileData, FileHeader, FileManifestParent, ProcessedFileData, SSAChunkMeta,
+    ChunkLocation};


### PR DESCRIPTION
Removed default values for window and dictionary parameters. They are now set in the run_compression function. Changed window and dictionary to be optional paramters. Added autotune_timeout optional parameter for allowing the user to specify the highest tolerable time for each autotune loop.

In compress.rs:
Removed ProcessedFileData struct from lib_sprite_shrink as it is no longer required. Adjusted formatting of lib_sprite_shrink functions. Updated function documentation for run_compression to include new functionality. Changed file_manifest, data_store, veri_hashes to be mutable and renamed with the preceeding underscore to supress compiler warnings of them not being read. Renamed _read_threads to _process_threads to be more representative of it's purpose. Renamed read_pool to _process_process to be more representative of it's purpose. Move parallel read and process each file to new process_files_with_window_size function in order to be more cleanly looped by autotune logic. Added autotune logic for determin optimal window and/or dictionary sizes to be sued by the finalize archive function. Moved the creation of file manifest and chunks and the data insertion for veri_hashes and file_manifest to process_files_with_window_size function in order to be more cleanly looped by autotune logic. Adjusted and renamed logic for task_threads and task_pool to be cleaner and remaned them to _compute_threads and _compute_pool accordingly. Adjusted the calling of finalize_archive to use new variables from auto_tuning refactor. Added process_files_with_window_size for frocessing a collection of files in parallel to produce core data structures.

In archive.rs:
Changed compress_with_dict to be public for use in new test_compression function in process.rs.

In lib.rs:
Add new test_compression function for public use outside of library. Adjust formatting of lib_structs.

In processing.rs:
Add rayon crate.
Add archive crate with compress_with_dict for use in new test_compression function. Add new test_compression function for testing compression with specific paramters and returning the compressed data size and dictionary size added together for use in auto-tune functionality.