### PR TITLE
Added quiet and verbose mode functionality.

### DIFF
--- a/crates/cli_application/src/modes/extract.rs
+++ b/crates/cli_application/src/modes/extract.rs
@@ -147,8 +147,10 @@ pub fn run_extraction(file_path: &PathBuf,
                 .collect();
             
             write_file(&final_output_path, file_data_ref)?;
-
-            println!("{} extracted successfully", &fmp.filename);
+            
+            if args.verbose{
+                println!("{} extracted successfully", &fmp.filename);
+            }
 
             Ok(())
         })

--- a/crates/lib_sprite_shrink/src/archive.rs
+++ b/crates/lib_sprite_shrink/src/archive.rs
@@ -8,7 +8,6 @@
 
 use std::{collections::HashMap, io::Write};
 use std::mem;
-use std::time::Instant;
 
 use bincode;
 
@@ -163,8 +162,6 @@ where
         .iter()
         .filter_map(|hash| data_store.get(hash).map(|data| data.as_slice()))
         .collect();
-    
-    let dict_start_time = Instant::now();
 
     //Make dictionary from sorted data.
     let mut _dictionary: Vec<u8> = Vec::new();
@@ -185,12 +182,8 @@ where
         ).map_err(|e| LibError::CompressionError(e.to_string()))?;
     }
 
-    let dict_elapsed_time = dict_start_time.elapsed();
-
     //Report progress after dictionary generation is done.
     progress_callback(Progress::DictionaryDone);
-
-    println!("The building dictionary took: {:?}", dict_elapsed_time);
     
     let task_pool = rayon::ThreadPoolBuilder::new()
         .num_threads(worker_threads)
@@ -198,8 +191,6 @@ where
         .map_err(|e| LibError::InternalLibError(format!("Failed to create thread pool: {}", e)))?;
 
     let compressed_dash: DashMap<u64, Vec<u8>> = DashMap::new();
-
-    //let comp_start_time = Instant::now();
 
     let comp_result: Result<(), LibError> = task_pool.install(|| {
         //Report that compression is starting
@@ -222,10 +213,6 @@ where
             Ok(())
         })
     });
-
-    //let elapsed_time = comp_start_time.elapsed();
-
-    //println!("The compression function took: {:?}", elapsed_time);
 
     //Check if any of the parallel operations failed.
     comp_result?;


### PR DESCRIPTION
compress.rs:
Added if statements for each print message to print only under verbose mode with exception of final print message that archive is successfully created.

Modified progress callback to only print certain messages under normal or verbose mode and nothing under quiet mode. Only the progress bar is printed to console under normal mode.

Added final println message that the archive has been successfully created at the provided path.

extract.rs:
Added if statements for the final print message to print only under verbose mode.

archive.rs:
Removed use std::time::Instant as it is no longer required.

Remove logic for recording dictionary and compression duration.

Remove commented out print logic.